### PR TITLE
Moved 'handleDocumentClick.bind' to the constructor

### DIFF
--- a/src/components/EventLocationFilter/EventLocationFilter.js
+++ b/src/components/EventLocationFilter/EventLocationFilter.js
@@ -25,14 +25,15 @@ class EventLocationFilter extends Component {
       location: '',
       range: distanceRange[1].value
     };
+    this.handleDocumentClick = this.handleDocumentClick.bind(this);
   }
 
   componentDidMount() {
-    window.addEventListener('click', this.handleDocumentClick.bind(this));
+    window.addEventListener('click', this.handleDocumentClick);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('click', this.handleDocumentClick.bind(this));
+    window.removeEventListener('click', this.handleDocumentClick);
   }
 
   // Close menu if clicking on the document (outside of the menu)


### PR DESCRIPTION
This allows removeEventListener to work. Every time you call .bind you
have a different reference.

See
http://stackoverflow.com/questions/14417890/does-bind-change-the-function-reference-how-to-set-permanently?lq=1

To recreate the issue on master, open up the "select location" modal, dismiss it then navigate to another page. In the error console, you'll see:

![pasted image](http://dl.dropbox.com/s/vz7u914jydsi2z5/Screenshot%202017-03-28%2017.43.18.png?dl=0)