### PR TITLE
Update to use v1/events (not facebook/events)

### DIFF
--- a/src/api/eventsAPI.js
+++ b/src/api/eventsAPI.js
@@ -682,11 +682,8 @@ const temp = {
 }
 /* eslint-enable */
 
-// NOTE: right now the server's _id property is inconsistent between fetches
-// so I'm hardcoding data for now
-
 function getEvents() {
-  // return axios.get('https://resistance-calendar.herokuapp.com/facebook/events')
+  // return axios.get('https://resistance-calendar.herokuapp.com/v1/events')
   //   .then(res => res.data);
 
   return new Promise(resolve => {
@@ -697,7 +694,7 @@ function getEvents() {
 }
 
 function getEventById(id) {
-  // return axios.get('https://resistance-calendar.herokuapp.com/facebook/events')
+  // return axios.get('https://resistance-calendar.herokuapp.com/v1/events?$filter=_id eq \'' + id + '\'')
   //   .then(res => res.data._embedded['osdi:events'].find(currEvent => currEvent._id === id));
 
   return new Promise(resolve => {


### PR DESCRIPTION
Use the newer endpoint for both list and detail fetches. Also get rid of an obsolete comment since it's no longer valid. 

Tested via local run connecting to the remote production instance.

I did not go so far as to remove the static instance since I know it may have some value still. Maybe we can switch based on the environment at some point. 