### PR TITLE
"add event" hide/display, addition of "cancel" button

### DIFF
--- a/src/components/AddEvent/AddEvent.js
+++ b/src/components/AddEvent/AddEvent.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 import styles from './AddEvent.sass';
-
 
 class AddEvent extends Component {
 
@@ -135,7 +135,12 @@ class AddEvent extends Component {
           />
         </fieldset>
         <fieldset className={styles.fieldset}>
-          <input type="submit" value="Submit" />
+          <div id={styles.buttonsContainer}>
+            <input type="submit" value="Submit" />
+            <Link to="/" className={styles.cancelBtn}>
+              CANCEL
+            </Link>
+          </div>
           <div className={styles.error}>{this.state.errorMessage.submission}</div>
         </fieldset>
       </form>

--- a/src/components/AddEvent/AddEvent.sass
+++ b/src/components/AddEvent/AddEvent.sass
@@ -1,4 +1,5 @@
 @import "~style/utils/variables.sass"
+@import "~style/utils/mixins.sass"
 
 #addEventForm
   max-width: $max-width
@@ -15,12 +16,26 @@
   textarea
     resize: vertical
 
-  input[type="submit"]
-    cursor: pointer
-    font-weight: 700
-    text-transform: uppercase
-    background-color: $main-green
-    color: $main-white
+
+
+  #buttons-container
+    display: flex
+
+    input[type="submit"]
+      flex: 3 0 0
+      -webkit-appearance: none
+      cursor: pointer
+      font-weight: 700
+      text-transform: uppercase
+      @include button($main-green, $main-white, $main-green)
+
+    .cancel-btn
+      flex: 1 0 0
+      @include button($main-medium-gray, $main-black, $main-medium-gray)
+      font-size: 15px
+      text-transform: uppercase
+      margin-left: $gutter-margin
+      text-align: center
 
   .error
     color: red

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,12 +3,14 @@ import React, { PropTypes } from 'react';
 import { Header, Footer } from '../';
 import styles from './App.sass';
 
-const App = ({ children }) => {
+const App = (props) => {
   return (
     <div className={styles.container}>
-      <Header />
+      <Header
+        pathName={props.location.pathname}
+      />
       <div className={styles.contentWrapper}>
-        {children}
+        {props.children}
       </div>
       <Footer />
     </div>
@@ -16,7 +18,10 @@ const App = ({ children }) => {
 };
 
 App.propTypes = {
-  children: PropTypes.element.isRequired
+  children: PropTypes.element.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string
+  }).isRequired
 };
 
 export default App;

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -4,14 +4,18 @@ import { shallow } from 'enzyme';
 import App from './App';
 
 describe('Component: <App />', () => {
+  const props = {};
+  props.location = {};
+  props.location.pathname = '';
+
   it('should render', () => {
-    const wrapper = shallow(<App><div /></App>);
+    const wrapper = shallow(<App {...props}><div /></App>);
 
     expect(wrapper).toHaveLength(1);
   });
 
   it('should render its children', () => {
-    const wrapper = shallow(<App><div className="child" /></App>);
+    const wrapper = shallow(<App {...props}><div className="child" /></App>);
     const children = wrapper.find('.child');
 
     expect(children).toHaveLength(1);

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Link } from 'react-router-dom';
 
 import { ResistanceLogo, AddEventButton } from '../';
 import styles from './Header.sass';
 
+function displayAddEventLink(path) {
+  if (path !== '/add-event') {
+    return <AddEventButton className="add-event-btn" />;
+  }
 
-const Header = () => {
+  return null;
+}
+
+const Header = (props) => {
   return (
     <header className={styles.header}>
       <div className={styles.headerLeftSection}>
@@ -14,12 +21,14 @@ const Header = () => {
         </Link>
       </div>
       <div className={styles.headerRightSection}>
-        <AddEventButton />
+        {displayAddEventLink(props.pathName)}
       </div>
     </header>
   );
 };
 
-Header.propTypes = {};
+Header.propTypes = {
+  pathName: PropTypes.string.isRequired
+};
 
 export default Header;

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -4,8 +4,27 @@ import { shallow } from 'enzyme';
 import Header from './Header';
 
 describe('Component: Header', () => {
+  const props = {};
+  props.location = {};
+  props.pathName = '';
+
   it('renders without crashing', () => {
-    const wrapper = shallow(<Header />);
+    const wrapper = shallow(<Header {...props} />);
+
     expect(wrapper).toHaveLength(1);
+  });
+
+  it('hides the "Add Events" button on the "Add Events" page', () => {
+    props.pathName = '/add-event';
+    const wrapper = shallow(<Header {...props} />);
+
+    expect(wrapper.find('.add-event-btn')).toHaveLength(0);
+  });
+
+  it('displays the "Add Events" button on the home page', () => {
+    props.pathName = '/';
+    const wrapper = shallow(<Header {...props} />);
+
+    expect(wrapper.find('.add-event-btn')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
* got add event button hiding and displaying when on /add-event route
* updated tests to verify button hide/display behavior
* added cancel button to add events page, takes user back to home page/event list

![resistance-calendar](https://cloud.githubusercontent.com/assets/2634159/24623186/32cf8cda-186d-11e7-9a92-3d77cb5a4264.png)

iPhone simulator view
<img width="310" alt="screen shot 2017-04-03 at 12 53 05 pm" src="https://cloud.githubusercontent.com/assets/2634159/24623191/38b0571a-186d-11e7-9535-c7d97dc8f3fc.png">
 