### PR TITLE
fix date selector bug

### DIFF
--- a/src/components/EventDateFilter/EventDateFilter.sass
+++ b/src/components/EventDateFilter/EventDateFilter.sass
@@ -55,6 +55,7 @@
     position: relative
     cursor: pointer
     font-size: 20px
+    border: 1px solid transparent
 
     &:focus
       outline: none

--- a/src/components/EventDateFilter/EventDateFilter.sass
+++ b/src/components/EventDateFilter/EventDateFilter.sass
@@ -55,7 +55,7 @@
     position: relative
     cursor: pointer
     font-size: 20px
-    border: 1px solid transparent
+    border: 1px solid transparent // needed because of border added on :focus
 
     &:focus
       outline: none


### PR DESCRIPTION
This is for #114 . I add a transparent border to the input so that when a green border is added to the `:focus` state, the input doesn't shift everything down.