### PR TITLE
Converted time and date display for date block and event cards to formats as specified in UX, removing PLACEHOLDER text (issue 116)

### DIFF
--- a/src/components/DateBlock/DateBlock.js
+++ b/src/components/DateBlock/DateBlock.js
@@ -1,20 +1,32 @@
 import React, { PropTypes } from 'react';
+import { dateTimeUtils } from '../../utils';
 
 import styles from './DateBlock.sass';
 
-const DateBlock = ({ date }) => {
-  const [dayName, month, dayNum] = (new Date(date)).toDateString().split(' ');
+const DateBlock = ({ startDate, endDate }) => {
+  const isMultiDayEvent = dateTimeUtils.dateTimeNoOffset(startDate, 'DDD') !== dateTimeUtils.dateTimeNoOffset(endDate, 'DDD');
+
+  //  get start date values
+  const [startDayName, startMonth, startDayNum] = dateTimeUtils.dateTimeNoOffset(startDate, 'ddd MMM D').split(' ');
+
+  //  get end date values
+  const [endMonth, endDayNum] = dateTimeUtils.dateTimeNoOffset(endDate, 'MMM D').split(' ');
+
+  // display appropriate info based on whether or not this is a multi-day event or not
+  const leftBox = isMultiDayEvent ? `${startMonth} ${startDayNum} -` : startDayName;
+  const rightBox = isMultiDayEvent ? `${endMonth} ${endDayNum}` : `${startMonth} ${startDayNum}`;
 
   return (
     <div className={styles.container}>
-      <span className={styles.left}>{dayName}</span>
-      <span className={styles.right}>{month} {dayNum}</span>
+      <span className={styles.left}>{leftBox}</span>
+      <span className={styles.right}>{rightBox}</span>
     </div>
   );
 };
 
 DateBlock.propTypes = {
-  date: PropTypes.string.isRequired
+  startDate: PropTypes.string.isRequired,
+  endDate: PropTypes.string,
 };
 
 export default DateBlock;

--- a/src/components/DateBlock/DateBlock.test.js
+++ b/src/components/DateBlock/DateBlock.test.js
@@ -7,7 +7,8 @@ describe('Component: DateBlock', () => {
   const props = {};
 
   beforeEach(() => {
-    props.date = '2015-03-14T12:00:00Z';
+    props.startDate = '2017-04-29T18:00:00-07:00';
+    props.endDate = '2017-04-29T21:00:00-07:00';
   });
 
   it('renders without crashing', () => {
@@ -18,5 +19,31 @@ describe('Component: DateBlock', () => {
   it('renders left and right spans', () => {
     const wrapper = shallow(<DateBlock {...props} />);
     expect(wrapper.find('span')).toHaveLength(2);
+  });
+
+  it('renders the correct date format in the left box', () => {
+    const wrapper = shallow(<DateBlock {...props} />);
+    const leftSpanText = wrapper.children('span').at(0).text().toLowerCase();
+    expect(leftSpanText).toBe('sat');
+  });
+
+  it('renders the correct date format in the left box', () => {
+    const wrapper = shallow(<DateBlock {...props} />);
+    const rightSpanText = wrapper.children('span').at(1).text().toLowerCase();
+    expect(rightSpanText).toBe('apr 29');
+  });
+
+  it('renders the correct date format in the left box for multi-day events', () => {
+    props.endDate = '2017-04-30T21:00:00-07:00';
+    const wrapper = shallow(<DateBlock {...props} />);
+    const rightSpanText = wrapper.children('span').at(0).text().toLowerCase();
+    expect(rightSpanText).toBe('apr 29 -');
+  });
+
+  it('renders the correct date format in the right box for multi-day events', () => {
+    props.endDate = '2017-04-30T21:00:00-07:00';
+    const wrapper = shallow(<DateBlock {...props} />);
+    const rightSpanText = wrapper.children('span').at(1).text().toLowerCase();
+    expect(rightSpanText).toBe('apr 30');
   });
 });

--- a/src/components/EventCard/EventCard.test.js
+++ b/src/components/EventCard/EventCard.test.js
@@ -8,7 +8,8 @@ describe('Component: EventCard', () => {
 
   beforeEach(() => {
     props.event = {
-      start_date: '2015-03-14T12:00:00Z'
+      start_date: '2017-04-29T18:00:00-07:00',
+      end_date: '2017-04-29T21:00:00-07:00'
     };
   });
 
@@ -22,5 +23,22 @@ describe('Component: EventCard', () => {
 
     expect(wrapper.find('Link')).toHaveLength(2);
     expect(wrapper.find('img')).toHaveLength(1);
+  });
+
+  it('displays the correct time format', () => {
+    const wrapper = shallow(<EventCard {...props} />);
+    const dateDisplay = wrapper.find('div').at(1).children('div').at(1)
+    .text()
+    .toLowerCase();
+    expect(dateDisplay).toBe('6:00 to 9:00 pm');
+  });
+
+  it('displays the correct time format for multi-day event', () => {
+    props.event.end_date = '2017-04-30T21:00:00-07:00';
+    const wrapper = shallow(<EventCard {...props} />);
+    const dateDisplay = wrapper.find('div').at(1).children('div').at(1)
+    .text()
+    .toLowerCase();
+    expect(dateDisplay).toBe('6:00 pm apr 29 - 9:00 pm apr 30');
   });
 });

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -99,7 +99,10 @@ class EventDetails extends Component {
     return (
       <div>
         <div className={styles.titleWrapper}>
-          <DateBlock date={startDate} />
+          <DateBlock
+            startDate={startDate}
+            endDate={endDate}
+          />
           <h1>{title}</h1>
           { location && location.locality &&
             <div className={styles.location}>{location.locality}, {location.region}</div>

--- a/src/utils/dateTimeUtils.js
+++ b/src/utils/dateTimeUtils.js
@@ -1,0 +1,11 @@
+import moment from 'moment';
+
+function dateTimeNoOffset(timeStamp, momentFormat) {
+  const offset = moment.parseZone(timeStamp).utcOffset();
+
+  return moment.utc(timeStamp).utcOffset(offset).format(momentFormat);
+}
+
+export default {
+  dateTimeNoOffset
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,2 @@
 export { default as queryBuilder } from './queryBuilder.js';  // eslint-disable-line import/prefer-default-export
+export { default as dateTimeUtils } from './dateTimeUtils.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,7 +4083,13 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@^2.17.1, moment@^2.18.1:
+moment-timezone@^0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.17.1, moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 


### PR DESCRIPTION
See #116 for details, will add details to this PR asap as needed (short on time at this moment, apologies!)