### PR TITLE
Makes add-event modal full width on smaller screens

### DIFF
--- a/src/components/AddEvent/AddEvent.sass
+++ b/src/components/AddEvent/AddEvent.sass
@@ -2,15 +2,16 @@
 @import "~style/utils/mixins.sass"
 
 #addEventForm
-  position: relative
   margin: auto
-  width: 80%
   text-align: left
   @include popover-wrapper(300px, 50px, right, 7px, 40px, $main-medium-light-gray)
   @media only screen and (max-width: $break-min-sm)
+    @include popover-wrapper(calc(100% - 45px), 50px, right, 7px, 40px, $main-medium-light-gray)
+    position: absolute
     margin: 0
-    right: 0
-    width: 174%
+    top: 68px
+    right: 5px
+    left: 5px
 
   input, textarea
     background-color: $main-white

--- a/src/components/Header/Header.sass
+++ b/src/components/Header/Header.sass
@@ -22,6 +22,9 @@
     text-align: right
     flex: none
 
+    @media only screen and (max-width: $break-min-sm)
+      position: inherit
+
 // Breakpoints
 @media only screen and (max-width: $max-width)
   .header


### PR DESCRIPTION
Resolves https://github.com/ResistanceCalendar/resistance-calendar-frontend/issues/123

--------

![screen shot 2017-05-05 at 1 50 50 pm](https://cloud.githubusercontent.com/assets/8879452/25744416/1bdba086-319a-11e7-9a8e-472fe6cd8021.png)
