### PR TITLE
Scroll events list only

### DIFF
--- a/src/components/Events/Events.sass
+++ b/src/components/Events/Events.sass
@@ -9,10 +9,12 @@
 
   .filters-wrapper
     width: 100%
+    height: $event-filters-height
     background-color: $main-white
-    position: relative
+    position: fixed
+    top: $header-height
     z-index: 1
-    box-shadow: 0px 2px 3px -1px rgba(0,0,0,0.6);
+    box-shadow: 0px 2px 3px -1px rgba(0,0,0,0.6)
 
   .load-more-btn
     text-align: center

--- a/src/components/EventsList/EventsList.sass
+++ b/src/components/EventsList/EventsList.sass
@@ -2,7 +2,7 @@
 
 .list-container
   max-width: $max-width
-  margin: 0 auto
+  margin: $nav-height auto 0
   background-color: $main-medium-gray
 
   .event-card
@@ -15,4 +15,4 @@
   .no-results
     font-weight: 700
     padding: 60px 0
-    text-align: center;
+    text-align: center

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -49,17 +49,19 @@ class Header extends Component {
   render() {
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
-      <header className={styles.header}>
-        <div className={styles.headerLeftSection}>
-          <Link to="/">
-            <ResistanceLogo />
-          </Link>
-        </div>
-        <div className={styles.headerRightSection} onClick={e => e.stopPropagation()}>
-          <AddEventButton className="add-event-btn" handleButtonClick={this.toggleModalState} />
-          {this.renderAddEventModal()}
-        </div>
-      </header>
+      <div className={styles.headerWrapper}>
+        <header className={styles.header}>
+          <div className={styles.headerLeftSection}>
+            <Link to="/">
+              <ResistanceLogo />
+            </Link>
+          </div>
+          <div className={styles.headerRightSection} onClick={e => e.stopPropagation()}>
+            <AddEventButton className="add-event-btn" handleButtonClick={this.toggleModalState} />
+            {this.renderAddEventModal()}
+          </div>
+        </header>
+      </div>
     );
     /* eslint-enable jsx-a11y/no-static-element-interactions */
   }

--- a/src/components/Header/Header.sass
+++ b/src/components/Header/Header.sass
@@ -1,31 +1,36 @@
 @import "~style/utils/variables.sass"
 @import "~style/utils/mixins.sass"
 
-.header
-  display: flex
-  flex-direction: row
-  margin: $gutter-margin-mobile auto
-  max-width: $max-width
-  justify-content: center
-  align-items: center
-  vertical-align: middle
+.header-wrapper
+  position: fixed
+  top: 0
+  width: 100%
+  height: $header-height
+  z-index: 100
+  background: #ec3659
 
-  // Let left section take up all the space it wants so button (right-section) is only as big as it needs to be
-  .header-left-section
-    flex: 1
-
-    .resistance-logo
-      width: 100%
-
-  .header-right-section
-    position: relative
-    text-align: right
-    flex: none
-
-    @media only screen and (max-width: $break-min-sm)
-      position: inherit
-
-// Breakpoints
-@media only screen and (max-width: $max-width)
   .header
-    margin: $gutter-margin-mobile
+    display: flex
+    flex-direction: row
+    justify-content: center
+    align-items: center
+    vertical-align: middle
+    margin: auto
+    max-width: $max-width
+
+    // Let left section take up all the space it wants so button (right-section) is only as big as it needs to be
+    .header-left-section
+      flex: 1
+      margin: $gutter-margin-mobile
+
+      .resistance-logo
+        width: 100%
+
+    .header-right-section
+      position: relative
+      margin-right: $gutter-margin-mobile
+      text-align: right
+      flex: none
+
+      @media only screen and (max-width: $break-min-sm)
+        position: inherit

--- a/src/style/utils/variables.sass
+++ b/src/style/utils/variables.sass
@@ -1,5 +1,8 @@
 // Layout
 $max-width: 1080px
+$header-height: 75px
+$event-filters-height: 110px
+$nav-height: 185px
 
 // Spacing
 $base-padding: 15px


### PR DESCRIPTION
Typically I would have wrapped both elements (the header and event filters) and fixed that to the top, but in this case it seemed best to fix each component separately.

![sticky_header](https://cloud.githubusercontent.com/assets/8726946/25768213/b95357a8-31ce-11e7-8ede-b68c905509d2.gif)

Please forgive the weird spacing in Header.js, I'm not at the laptop I normally use so I think one of my vim settings is off, I'll fix that ASAP.
