### PR TITLE
created flag to set images to default to prevent Cloudinary requests during development work 

### DIFF
--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router-dom';
 import _ from 'lodash';
+import { devMode } from '../../config';
 
 import { dateTimeUtils } from '../../utils';
 import { DateBlock } from '../';
@@ -40,7 +41,7 @@ const EventCard = ({ event, className }) => {
   } = event;
 
   // TODO: May have to change how this check is done once we switch over to real default image
-  const croppedFeaturedImageUrl = featuredImageUrl ? getCroppedImageUrl(featuredImageUrl) : '../static/img/default-event-200.png';
+  const croppedFeaturedImageUrl = !devMode && featuredImageUrl ? getCroppedImageUrl(featuredImageUrl) : '../static/img/default-event-200.png';
 
   return (
     <li className={`${styles.card} ${className || ''}`}>

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { DateBlock, Loading, SocialBtns } from '../';
 import { eventsAPI } from '../../api';
 import { dateTimeUtils } from '../../utils';
+import { devMode } from '../../config';
 
 import styles from './EventDetails.sass';
 
@@ -106,7 +107,7 @@ class EventDetails extends Component {
         </div>
         <div className={styles.content}>
           <div className={styles.left}>
-            <img src={featuredImageUrl || '../static/img/default-event-600x360.png'} alt="featured event" />
+            <img src={devMode || !featuredImageUrl ? '../static/img/default-event-600x360.png' : featuredImageUrl} alt="featured event" />
           </div>
 
           <div className={styles.right}>

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,11 @@
 export const facebookAppId = '274135313007103';
 
-export default facebookAppId;
+// The code below is a stop-gap while we come up with a more economic
+// solution to Cloudinary.
+// Set overridedevMode to true if you want to work locally
+// but see the live images as they'd appear in production. We are
+// using this flag so as to avoid exceeding traffic limitiations
+// of Cloudinary, so CHECK WITH DEVIN OR ONE OF THE API DEVS TO
+// MAKE SURE WE AREN'T CLOSE TO OUR BANDWIDTH LIMIT.
+const overrideDevMode = false;
+export const devMode = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') && !overrideDevMode;


### PR DESCRIPTION
This is a fairly urgent stop-gap measure to have all event images on the site go to the default/placeholder image, since we're about to run into the Cloudinary limit just from the dev work, which would mean some significant charges. 

Hopefully we'll soon have another hosting solution so we can remove these changes, or at least set the devMode flag to return false by default so we can see the actual live images while doing our dev work.

Once this is merged in, then locally, every single event image will be the placeholder, but as soon as we deploy to staging and beyond, the actual event images should indeed show up.