### PR TITLE
fixed bug with missing end date in date block defaulting to today's date

### DIFF
--- a/src/components/DateBlock/DateBlock.js
+++ b/src/components/DateBlock/DateBlock.js
@@ -4,7 +4,7 @@ import { dateTimeUtils } from '../../utils';
 import styles from './DateBlock.sass';
 
 const DateBlock = ({ startDate, endDate }) => {
-  const isMultiDayEvent = dateTimeUtils.dateTimeNoOffset(startDate, 'DDD') !== dateTimeUtils.dateTimeNoOffset(endDate, 'DDD');
+  const isMultiDayEvent = endDate ? dateTimeUtils.dateTimeNoOffset(startDate, 'DDD') !== dateTimeUtils.dateTimeNoOffset(endDate, 'DDD') : false;
 
   //  get start date values
   const [startDayName, startMonth, startDayNum] = dateTimeUtils.dateTimeNoOffset(startDate, 'ddd MMM D').split(' ');


### PR DESCRIPTION
**BEFORE:**
![image](https://cloud.githubusercontent.com/assets/2634159/26710143/75b36d80-471d-11e7-9193-99f952a49b06.png)

**AFTER:**
<img width="907" alt="screen shot 2017-06-01 at 10 54 45 pm" src="https://cloud.githubusercontent.com/assets/2634159/26710120/5edf13d4-471d-11e7-9728-21ca39ec43ce.png">
<img width="594" alt="screen shot 2017-06-01 at 10 54 40 pm" src="https://cloud.githubusercontent.com/assets/2634159/26710121/5ee548ee-471d-11e7-8225-dc787cda7d99.png">
