### PR TITLE
Add Event Modal doesnt get stuck rendering Redirect after submit

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import axios from 'axios';
 
 import { ResistanceLogo, AddEventButton, AddEvent } from '../';
@@ -13,6 +13,7 @@ class Header extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      addEventModalExists: false,
       addEventModalOpen: false
     };
 
@@ -28,13 +29,22 @@ class Header extends Component {
     window.removeEventListener('click', this._handleDocumentClick);
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      this.setState({ addEventModalExists: false})
+    }
+  }
+
   // Close menu if clicking on the document (outside of the menu)
   handleDocumentClick() {
     this.setState({ addEventModalOpen: false });
   }
 
   toggleModalState() {
-    this.setState({ addEventModalOpen: !this.state.addEventModalOpen });
+    this.setState({
+      addEventModalExists: true,
+      addEventModalOpen: !this.state.addEventModalOpen
+    });
   }
 
   renderAddEventModal() {
@@ -58,7 +68,7 @@ class Header extends Component {
           </div>
           <div className={styles.headerRightSection} onClick={e => e.stopPropagation()}>
             <AddEventButton className="add-event-btn" handleButtonClick={this.toggleModalState} />
-            {this.renderAddEventModal()}
+            {this.state.addEventModalExists && this.renderAddEventModal()}
           </div>
         </header>
       </div>
@@ -70,4 +80,4 @@ class Header extends Component {
 Header.propTypes = {
 };
 
-export default Header;
+export default withRouter(Header);

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-
+import { shallow, mount } from 'enzyme';
+import { MemoryRouter } from 'react-router';
 import Header from './Header';
 
 describe('Component: Header', () => {
@@ -11,26 +11,14 @@ describe('Component: Header', () => {
   });
 
   it('Add event form is closed by default', () => {
-    const header = shallow(<Header {...props} />);
+    const header = mount(<MemoryRouter><Header {...props} /></MemoryRouter>);
 
-    const modalContainer1 = header.find('#modal-container');
-    const modalContainerDisplay1 = modalContainer1.node.props.style.display;
+    expect(header.find('#modal-container').length).toBe(0);
+    expect(header.find('AddEvent')).toHaveLength(0);
 
-    expect(modalContainerDisplay1).toBe('none');
+    header.find("button").simulate('click')
 
-    header.setState({ addEventModalOpen: true });
-
-    const modalContainer2 = header.find('#modal-container');
-    const modalContainerDisplay2 = modalContainer2.node.props.style.display;
-
-    expect(modalContainerDisplay2).toBe('block');
-  });
-
-  it('Add event form is managed by state', () => {
-    const header = shallow(<Header {...props} />);
-
-    header.setState({ addEventModalOpen: true });
-
+    expect(header.find('#modal-container').length).toBe(1);
     expect(header.find('AddEvent')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes #171

After the location changes, lets blow away all of the state of the modal. If we don't do that, a submitted form will continue rendering a `Redirect`
