### PR TITLE
fix production deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rimraf dist && webpack -p",
     "dev": "webpack-dev-server",
-    "start": " serve -s dist",
+    "start": "yarn install  && serve -s dist",
     "heroku-postbuild": "rm -rf dist && NODE_ENV=production webpack -p --progress --colors",
     "test": "jest --config=testConfig/jest.config.json --coverage",
     "test:watch": "jest --config=testConfig/jest.config.json --watch --coverage",


### PR DESCRIPTION
Production is not updating on deploy because  `dist` directory update included in `heroku-postbuild`  only fires after install. Trigger this with `start`.