### PR TITLE
Add missing linebreaks in FB Event descriptions

### DIFF
--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -92,7 +92,7 @@ class EventDetails extends Component {
       location
     } = event;
 
-    const descriptionHtml = { __html: description.replace(/\n/g, '<br/>') };
+    const descriptionHtml = description ? { __html: description.replace(/\n/g, '<br/>') } : null;
 
     const featuredImageUrlOrDefault = (!devMode && featuredImageUrl) ?
       urlUtils.getImageUrl(featuredImageUrl, 'c_lfill,w_800') :

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -92,11 +92,14 @@ class EventDetails extends Component {
       location
     } = event;
 
+    const descriptionHtml = { __html: description.replace(/\n/g, '<br/>') };
+
     const featuredImageUrlOrDefault = (!devMode && featuredImageUrl) ?
       urlUtils.getImageUrl(featuredImageUrl, 'c_lfill,w_800') :
       '../static/img/default-event-600x360.png';
 
     /* eslint-disable jsx-a11y/no-static-element-interactions */
+    /* eslint-disable react/no-danger */
     return (
       <div className={styles.container}>
         <div className={styles.titleWrapper}>
@@ -171,14 +174,13 @@ class EventDetails extends Component {
           </div>
 
           <div className={styles.description}>
-            <p>
-              {description}
-            </p>
+            <p dangerouslySetInnerHTML={descriptionHtml} />
           </div>
         </div>
       </div>
     );
     /* eslint-enable jsx-a11y/no-static-element-interactions */
+    /* eslint-enable react/no-danger */
   }
 }
 

--- a/src/components/EventDetails/EventDetails.test.js
+++ b/src/components/EventDetails/EventDetails.test.js
@@ -64,4 +64,16 @@ describe('Component: EventDetails', () => {
 
     expect(dateTimeUtils.displayTimeString(event.start_date, event.end_date).toLowerCase()).toBe('6:00 pm');
   });
+
+  it('keeps linebreaks in descriptions', () => {
+    event.description = `Protest Illiad.
+
+      God, the Pence Administration sucks.
+    `;
+
+    const wrapper = shallow(<EventDetails {...props} />);
+    wrapper.setState({ event, isFetchingEvent: false });
+
+    expect(wrapper.html().includes('<br/>')).toBe(true);
+  });
 });


### PR DESCRIPTION
Events from Facebook have `\n` and not `<br/>`. As a result, all the text that's formatted in FB descriptions are getting munged together.

**Before:**

![pasted image](http://dl.dropbox.com/s/bh6zr2k816x7aws/Screenshot%202017-07-02%2015.21.55.png?dl=0)

**After:**

![pasted image](http://dl.dropbox.com/s/rm6ke89o0v2qhy3/Screenshot%202017-07-02%2015.21.27.png?dl=0)