### PR TITLE
Fixed bug caused by apostrophe in search input (#188)

### DIFF
--- a/src/components/EventCard/EventCard.test.js
+++ b/src/components/EventCard/EventCard.test.js
@@ -9,7 +9,8 @@ describe('Component: EventCard', () => {
   beforeEach(() => {
     props.event = {
       start_date: '2017-04-29T18:00:00-07:00',
-      end_date: '2017-04-29T21:00:00-07:00'
+      end_date: '2017-04-29T21:00:00-07:00',
+      total_accepted: 1200,
     };
   });
 

--- a/src/components/EventDetails/EventDetails.sass
+++ b/src/components/EventDetails/EventDetails.sass
@@ -178,7 +178,7 @@
           display: none
 
         .popover-wrapper
-          @include popover-wrapper(250px, 29px, right, -33px, 85px)
+          @include popover-wrapper(250px, 29px, right, -8px, 61px)
 
           a
             margin-right: 0

--- a/src/components/EventDetails/EventDetails.test.js
+++ b/src/components/EventDetails/EventDetails.test.js
@@ -21,7 +21,8 @@ describe('Component: EventDetails', () => {
       summary: '',
       location: {
         address_lines: []
-      }
+      },
+      total_accepted: 1200,
     };
   });
 

--- a/src/components/Events/Events.js
+++ b/src/components/Events/Events.js
@@ -128,7 +128,8 @@ class Events extends Component {
 
     // Filter values
     const { filters, geoLocation } = this.state;
-    const mergedFilters = Object.assign({}, filters, { geoLocation });
+
+    const mergedFilters = Object.assign({}, this.cleanSearchText(filters), { geoLocation });
     const odataValues = buildFilterValues(mergedFilters, odataFilterTypes);
     const nonOdataValues = buildFilterValues(mergedFilters, nonOdataFiltertypes);
 
@@ -153,6 +154,16 @@ class Events extends Component {
         eventsStorage.clearCache();
         this.setState({ isFetchingEvents: false });
       });
+  }
+
+  cleanSearchText(filterData) {
+    // removes apostrophes from user input to avoid broken searches
+    // without affecting what the user sees in the search box
+    const filtersClean = Object.assign({}, filterData);
+    if (filtersClean.searchText) {
+      filtersClean.searchText = filtersClean.searchText.replace(/'/g, '');
+    }
+    return filtersClean;
   }
 
   // When loading more results for a current search
@@ -203,9 +214,9 @@ class Events extends Component {
 
   updateQueryString() {
     const updatedFilters = _.pickBy(this.state.filters);  // make new object and return new object
-    updatedFilters.startDate = dateTimeUtils.getMomentISOstring(updatedFilters.startDate);
 
-    const updatedQueryString = queryString.stringify(updatedFilters);
+    updatedFilters.startDate = dateTimeUtils.getMomentISOstring(updatedFilters.startDate);
+    const updatedQueryString = queryString.stringify(this.cleanSearchText(updatedFilters));
     this.props.history.push('?' + updatedQueryString);
   }
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
+
 import { withRouter, Link } from 'react-router-dom';
 import axios from 'axios';
 
@@ -25,14 +26,16 @@ class Header extends Component {
     window.addEventListener('click', this._handleDocumentClick);
   }
 
-  componentWillUnmount() {
-    window.removeEventListener('click', this._handleDocumentClick);
-  }
-
   componentDidUpdate(prevProps) {
     if (this.props.location !== prevProps.location) {
-      this.setState({ addEventModalExists: false})
+      /* eslint-disable react/no-did-update-set-state */
+      this.setState({ addEventModalExists: false });
+      /* eslint-enable react/no-did-update-set-state */
     }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('click', this._handleDocumentClick);
   }
 
   // Close menu if clicking on the document (outside of the menu)
@@ -78,6 +81,7 @@ class Header extends Component {
 }
 
 Header.propTypes = {
+  location: PropTypes.shape(),
 };
 
 export default withRouter(Header);

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import Header from './Header';
 
 describe('Component: Header', () => {
@@ -16,7 +16,7 @@ describe('Component: Header', () => {
     expect(header.find('#modal-container').length).toBe(0);
     expect(header.find('AddEvent')).toHaveLength(0);
 
-    header.find("button").simulate('click')
+    header.find('button').simulate('click');
 
     expect(header.find('#modal-container').length).toBe(1);
     expect(header.find('AddEvent')).toHaveLength(1);


### PR DESCRIPTION
* Stripped out apostrophes without affecting the component state, so that the user still sees the apostrophe in the search box, but the search text going to the API as well as into query string do not have the apostrophe
* Fix 2 broken unit tests and miscellaneous linting errors
* Adjusted CSS on share popup so that it wouldn't float partially off the screen (see images below)

BEFORE:
<img width="369" alt="before" src="https://user-images.githubusercontent.com/2634159/30225810-715c1e02-9499-11e7-80b8-aab078ffa3c7.png">
AFTER:
<img width="372" alt="after" src="https://user-images.githubusercontent.com/2634159/30225815-74f0542a-9499-11e7-85b6-fe99863849a6.png">
