### PR TITLE
Hide RSVP tags for events with zero attendees (#190)

### DIFF
--- a/src/components/EventCard/EventCard.js
+++ b/src/components/EventCard/EventCard.js
@@ -55,7 +55,10 @@ const EventCard = ({ event, className }) => {
           </Link>
         </div>
 
-        <RsvpBadge totalAccepted={totalAccepted} center type='desktopOnly'/>
+        {
+          totalAccepted > 0 &&
+          <RsvpBadge totalAccepted={totalAccepted} center />
+        }
       </div>
 
       <div className={styles.contentWrapper}>

--- a/src/components/EventCard/EventCard.test.js
+++ b/src/components/EventCard/EventCard.test.js
@@ -9,7 +9,8 @@ describe('Component: EventCard', () => {
   beforeEach(() => {
     props.event = {
       start_date: '2017-04-29T18:00:00-07:00',
-      end_date: '2017-04-29T21:00:00-07:00'
+      end_date: '2017-04-29T21:00:00-07:00',
+      total_accepted: 1,
     };
   });
 
@@ -23,6 +24,18 @@ describe('Component: EventCard', () => {
 
     expect(wrapper.find('Link')).toHaveLength(2);
     expect(wrapper.find('img')).toHaveLength(1);
+  });
+
+  it('renders RsvpBadge if there are one or more RSVPs', () => {
+    const wrapper = shallow(<EventCard {...props} />);
+
+    expect(wrapper.find('RsvpBadge')).toHaveLength(1);
+  });
+
+  it('does NOT render RsvpBadge if there no RSVPs', () => {
+    props.event.total_accepted = 0;
+    const wrapper = shallow(<EventCard {...props} />);
+    expect(wrapper.find('RsvpBadge').exists()).toBe(false);
   });
 
   it('displays the correct time format', () => {

--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -110,9 +110,12 @@ class EventDetails extends Component {
               endDate={endDate}
             />
 
-            <RsvpBadge
-              totalAccepted={totalAccepted}
-            />
+            {
+              totalAccepted > 0 &&
+              <RsvpBadge
+                totalAccepted={totalAccepted}
+              />
+            }
           </div>
           <h1>{title}</h1>
           { location && location.locality &&


### PR DESCRIPTION
Looks like the RSVP badges are not in prod yet, but in any event, locally, here is what I have.

**NOTE** - Tried adding a test for RSVP badge for event details using same approach as event card, but didn't work, and didn't have time to debug, so would love to get any feedback on that (still sort of a Jest n00b). 
<img width="1166" alt="eventlist" src="https://user-images.githubusercontent.com/2634159/30232625-a5995b40-94b6-11e7-97f5-629dfef08589.png">
<img width="1157" alt="eventdetail" src="https://user-images.githubusercontent.com/2634159/30232626-a5a044b4-94b6-11e7-835f-17131d5df4ac.png">
