### PR TITLE
Switched default sorting back to by date, added meta description for search engines

### DIFF
--- a/src/components/Events/Events.js
+++ b/src/components/Events/Events.js
@@ -45,7 +45,7 @@ class Events extends Component {
       filters: {
         searchText: parsedQueryString.searchText || '',
         location: parsedQueryString.location || null,
-        orderby: parsedQueryString.orderby || 'total_accepted',
+        orderby: parsedQueryString.orderby || 'start_date desc',
         range: parseInt(parsedQueryString.range, 10) || distanceRange[defaultRangeIndex].value,
         startDate: moment(parsedQueryString.startDate),  // if undefined, will create an object representing today
       },

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,7 @@
   <base href="/">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
+  <meta name="description" content="A massive central listing of upcoming progressive events. ORGANIZE, RESIST, REPEAT.">
   <link rel="manifest" href="static/manifest.json" />
   <link rel="icon" sizes="32x32" type="image/png" href="static/img/favicon.ico" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet" />


### PR DESCRIPTION
@InciteDemocracy Here is the meta description I used (took from Twitter):

> "A grassroots volunteer-run listing of progressive political action. Everywhere."

![sort-by-date-default](https://user-images.githubusercontent.com/2634159/34634868-049dc000-f24e-11e7-95f4-8c695ba52513.gif)

Might be good to have @pdw207 take a look to make sure I changed the default sorting properly, although it seems pretty straightforward. 
