### PR TITLE
Fixed bug preventing rich previews from working when sharing via the Facebook share button (#204)

### DIFF
--- a/src/components/EventDetails/EventDetails.sass
+++ b/src/components/EventDetails/EventDetails.sass
@@ -178,7 +178,7 @@
           display: none
 
         .popover-wrapper
-          @include popover-wrapper(250px, 29px, right, -33px, 85px)
+          @include popover-wrapper(250px, 29px, right, -13px, 66px)
 
           a
             margin-right: 0

--- a/src/services/facebookSDK.js
+++ b/src/services/facebookSDK.js
@@ -3,30 +3,38 @@ import { facebookAppId } from '../config';
 
 export default {
   init() {
-    window.fbAsyncInit = function() {
-      FB.init({
-        appId      : facebookAppId,
-        xfbml      : true,
-        version    : 'v2.9'
-      });
-      FB.AppEvents.logPageView();
-    };
-    (function(d, s, id){
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) {return;}
-      js = d.createElement(s); js.id = id;
-      js.src = "//connect.facebook.net/en_US/sdk.js";
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));
+      window.fbAsyncInit = function() {
+        FB.init({
+          appId      : facebookAppId,
+          xfbml      : true,
+          version    : 'v2.11'
+        });
+        FB.AppEvents.logPageView();
+      };
+
+      (function(d, s, id){
+         var js, fjs = d.getElementsByTagName(s)[0];
+         if (d.getElementById(id)) {return;}
+         js = d.createElement(s); js.id = id;
+         js.src = 'https://connect.facebook.net/en_US/sdk.js';
+         fjs.parentNode.insertBefore(js, fjs);
+       }(document, 'script', 'facebook-jssdk'));
   },
   share({ title, eventDate, picture, eventUrl, description }) {
     FB.ui({
-      method: 'share',
-      href: eventUrl,
-      caption: eventDate,
-      title,
-      description,
-      picture
+      method: 'share_open_graph',
+      action_type: 'og.shares',
+      action_properties: JSON.stringify({
+        object: {
+          'fb:app_id': facebookAppId,
+          'og:url': eventUrl,
+          'og:title': title,
+          'og:description': description,
+          'og:image': picture,
+          'og:image:width': '600',
+          'og:image:height': '350'
+        }
+      })
     });
   }
 };


### PR DESCRIPTION
**IMPORTANT** - Make sure to test this on http://beta.resistancecalendar.org/ before going to prod, just to make sure that this code is working properly with the existing FB sharing app.

* Updated FB.ui() params to supply missing open graph metadata. 
* (unrelated to original issue but important) - slightly repositioned share popover so that it would no longer go offscreen at mobile width

![fb-share](https://user-images.githubusercontent.com/2634159/35194993-70c9db20-fe82-11e7-838e-98af5647b853.gif)

<img width="298" alt="reposition-share" src="https://user-images.githubusercontent.com/2634159/35195146-b4e1d7e8-fe84-11e7-91c1-7e82833471d1.png">

