### PR TITLE
Bug Fix: Handle partial completed addresses

### DIFF
--- a/src/components/EventDetails/EventDetails.js
+++ b/src/components/EventDetails/EventDetails.js
@@ -8,14 +8,19 @@ import styles from './EventDetails.sass';
 
 const renderAddress = (location) => {
   const { address_lines: addressLines, locality, region, postal_code: postalCode } = location;
-  // Will have to see how this data structure holds up over different events
-  return (
-    <div className={styles.info}>
-      <div className={styles.infoLabel}>location</div>
-      { addressLines[0] && <div>{addressLines[0]}</div> }
-      <div>{locality} {region}, {postalCode}</div>
-    </div>
-  );
+  const hasAddressFields = [locality, region, addressLines[0]].some((attr)=> !!attr)
+
+  if (hasAddressFields){
+    return (
+      <div className={styles.info}>
+        <div className={styles.infoLabel}>location</div>
+        {
+          addressLines.map((line, index) => line && <div key={index}>{line}</div>)
+        }
+        <div>{locality} {region}{postalCode && `, ${postalCode}`} </div>
+      </div>
+    );
+  }
 };
 
 const renderTimeRange = (startDate, endDate) => {


### PR DESCRIPTION
## Changes
- [x] List full address (previously list just the first address line)
- [x] Remove location block if not present
- [x] Remove trailing comma if zip is not provided

## National Event Before:
<img width="213" alt="screen shot 2018-03-02 at 1 25 48 pm" src="https://user-images.githubusercontent.com/4714249/36915054-4d857a10-1e1d-11e8-96de-8ea005de55b3.png">

## National Event After:

<img width="209" alt="screen shot 2018-03-02 at 1 25 35 pm" src="https://user-images.githubusercontent.com/4714249/36915059-52606f40-1e1d-11e8-9b37-7d5c395bd76d.png">
